### PR TITLE
Fix for extraction of JID from DISCO request

### DIFF
--- a/lib/api/api_util.js
+++ b/lib/api/api_util.js
@@ -157,19 +157,20 @@ function sendDiscoInfo(req, res, server, callback) {
 
 function queryAdvertisedServers(req, res, server, callback) {
     sendDiscoItems(req, res, server, function(reply) {
-    	jidExtract = function(jidAttr) {
-    		if (typeof(jidAttr.text) == 'function') {
-    			return jidAttr.text();
-            }
-    		jid = /jid\=\"(.*)\"/.exec(jidAttr);
-    		return jid[1];
-    	}
         var replyDoc = xml.parseXmlString(reply.toString());
         var servers = replyDoc.
             find('//disco:item/@jid', {disco: discoItemsNS}).
-            map(jidExtract);
+            map(this.jidExtract);
         queryEachServer(req, res, servers, callback);
     });
+}
+
+function jidExtract(jidAttr) {
+    if (typeof(jidAttr.text) == 'function') {
+	    return jidAttr.text();
+    }
+    jid = /jid\=\"(.*)\"/.exec(jidAttr);
+    return jid[1];
 }
 
 function sendDiscoItems(req, res, server, callback) {


### PR DESCRIPTION
Was failing on a standard Amazon AMI, assume there's a slightly different XML parser being used.

Before change server was returning 500 and node complaining that jidAttr had no method called text().

After fix working on both an ubuntu ec2 image, and standard amazon ami.
