### PR TITLE
Added init script for centos (second try)

### DIFF
--- a/contrib/buddycloud-http-api.conf
+++ b/contrib/buddycloud-http-api.conf
@@ -1,84 +1,8 @@
-#!/bin/bash
-#
-# wrapper script to start buddycloud-http-api (works in Centos 5)
-#
-# usage: buddycloud-http-api.init.centos start|stop|restart|status
-#
-# This file should work as an old style init script for the
-# buddycloud http api if you copy it to /etc/init.d. (But
-# has not been tested this way).
-# You can also use it for starting the server manually in
-# the background as above.
-# To install, copy it to a suitable location (possibly with
-# a shorter name), and set the variable declarations below
-# to something sensible for your system.
+# buddycloud-http-api - buddycloud HTTP API server 
+# script for upstart services (place in /etc/init)
 
-PREFIX=$HOME
-PROG_NAME=buddycloud-http-api
-PROG_DIR=$PREFIX/lib/node_modules/$PROG_NAME
-PID_PATH=$PREFIX/var/run/${PROG_NAME}.pid
-LOG_FILE=$PREFIX/var/log/${PROG_NAME}.log
-PROG_OPTS=""
-PROG='buddycloud HTTP API'
+description     "buddycloud HTTP API server"
 
-export LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
-export PATH=$PREFIX/bin/:$PATH
+respawn
+exec su nobody -c "/usr/bin/node /opt/buddycloud-http-api/server.js > /var/log/buddycloud-http-api.log 2>&1"
 
-start() {
-    # Check that networking is up. 
-    # (This line will only work in CentOS / RedHat / Fedora
-    # based distros but should have no effect otherwise).
-    # The rest is pretty generic.
-    [ "$NETWORKING" = "no" ] && exit 1
-	
-    echo -n "Starting $PROG: "
-    cd $PROG_DIR
-	nohup node server.js $PROG_OPTS < /dev/null >$LOG_FILE 2>&1 &
-	RETVAL=$?
-	echo $! > $PID_PATH
-	return $RETVAL
-}
-	
-stop() {
-    echo -n "Shutting down $PROG: "
-	kill `cat $PID_PATH`
-	RETVAL=$?
-	return $RETVAL
-}
-
-# See how we were called.
-case "$1" in
-    start)
-	    start
-        ;;
-    stop)
-	    stop
-        ;;
-    status)
-        echo -n "Status for $PROG: "
-        if ps `cat $PID_PATH` > /dev/null 2>&1 ; then
-            echo "RUNNING"
-        else
-            echo "STOPPED"
-        fi
-        RETVAL=-1
-        ;;
-    restart|reload)
-	    stop
-	    start
-	    RETVAL=$?
-	    ;;
-    *)
-        echo $"Usage: $0 {start|stop|restart|status}"
-        RETVAL=-1
-esac
-
-if [ "$RETVAL" != "-1" ]; then
-    if [ "$RETVAL" == "0" ] ; then 
-        echo OK
-    else
-        echo FAILED
-    fi
-    exit $RETVAL
-fi
-exit 0

--- a/contrib/buddycloud-http-init
+++ b/contrib/buddycloud-http-init
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# wrapper script to start buddycloud-http-api (works in Centos 5)
+# wrapper script to start buddycloud-http-api
 # usage: buddycloud-http-api.init.centos start|stop|restart|status
 #
 # This file should work as an old style init script for the
@@ -11,10 +11,12 @@
 # To install, copy it to a suitable location (possibly with
 # a shorter name), and set the variable declarations below
 # to something sensible for your system.
+# It has been tested under CentOS 5, but should work OK in other linux
+# distros.
 
-PREFIX=$HOME
+PREFIX=/opt
 PROG_NAME=buddycloud-http-api
-PROG_DIR=$PREFIX/lib/node_modules/$PROG_NAME
+PROG_DIR=$PREFIX/$PROG_NAME
 PID_PATH=$PREFIX/var/run/${PROG_NAME}.pid
 LOG_FILE=$PREFIX/var/log/${PROG_NAME}.log
 PROG_OPTS=""


### PR DESCRIPTION
As before, this is only tested under CentOS 5, used manually. It should work as a SysV init script under most distros, but isn't going to be ideal for all of them, and hasn't been tested that way.

I've also added a .gitignore file.
