### PR TITLE
Don't send broadcast presence

### DIFF
--- a/src/util/session.js
+++ b/src/util/session.js
@@ -290,7 +290,6 @@ Session.prototype.onStanza = function(handler) {
 
 Session.prototype.sendPresenceOnline = function() {
   if (this._presenceCount == 0) {
-    this._sendPresence(undefined);
     this._sendPresence(undefined, config.channelDomain);
   } else {
     this._presenceCount++;
@@ -299,7 +298,6 @@ Session.prototype.sendPresenceOnline = function() {
 
 Session.prototype.sendPresenceOffline = function() {
   if (this._presenceCount > 0) {
-    this._sendPresence('unavailable');
     this._sendPresence('unavailable', config.channelDomain);
     this._presenceCount--;
   }


### PR DESCRIPTION
If the HTTP API server sends a broadcast <presence/>, the user will appear
online in Jabber clients. It's enough to send them to the channel domain only.

Fixes #17.
