### PR TITLE
Kills process based on PID instead of the name of the process

### DIFF
--- a/contrib/buddycloud-http-init
+++ b/contrib/buddycloud-http-init
@@ -64,8 +64,8 @@ do_start()
 
     start-stop-daemon --start --pidfile $PIDFILE --exec $DAEMON --chuid $RUN_AS_USER --test > /dev/null \
         || return 1
-    start-stop-daemon --start --background --pidfile $PIDFILE --chdir $RUNDIR --chuid $RUN_AS_USER --exec /bin/bash -- \
-     -c "$DAEMON $DAEMON_ARGS > $LOGFILE 2>&1" \
+    start-stop-daemon --start --background --pidfile $PIDFILE --chdir $RUNDIR --chuid $RUN_AS_USER \
+    --exec /bin/bash -- -c "$DAEMON $DAEMON_ARGS >> $LOGFILE 2>&1 & echo "\$!" > $PIDFILE" \
         || return 2
     # Add code here, if necessary, that waits for the process to be ready
     # to handle requests from services started subsequently which depend
@@ -82,7 +82,7 @@ do_stop()
     #   1 if daemon was already stopped
     #   2 if daemon could not be stopped
     #   other if a failure occurred
-    start-stop-daemon --stop --quiet --retry=TERM/5/KILL/5 --pidfile $PIDFILE --name $NAME
+    start-stop-daemon --stop --quiet --retry=TERM/5/KILL/5 --pidfile $PIDFILE
     RETVAL="$?"
     [ "$RETVAL" = 2 ] && return 2
     # Wait for children to finish too if this is a daemon that forks
@@ -91,7 +91,7 @@ do_stop()
     # that waits for the process to drop all resources that could be
     # needed by services started subsequently.  A last resort is to
     # sleep for some time.
-    start-stop-daemon --stop --quiet --oknodo --retry=0/5/KILL/5 --exec $DAEMON
+    start-stop-daemon --stop --quiet --oknodo --retry=0/5/KILL/5 --pidfile $PIDFILE
     [ "$?" = 2 ] && return 2
     # Many daemons don't delete their pidfiles when they exit.
     rm -f $PIDFILE
@@ -107,7 +107,7 @@ do_reload() {
     # restarting (for example, when it is sent a SIGHUP),
     # then implement that here.
     #
-    start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $NAME
+    start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE
     return 0
 }
 


### PR DESCRIPTION
That would kill all running node processes.
