### PR TITLE
Highlight the option to set xmpp host in the example config

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -29,6 +29,9 @@ exports.production = {
   // the domain your run buddycloud for (if your username is name@example.com then this would be example.com)
   xmppDomain: 'example.com',
 
+  // Hostname (optional - if not provided SRV records will looked up and used)
+  // xmppHost: '1.2.3.4',
+ 
   // the anonymous domain that unauthenticated users are dropped into (should match your XMPP server)
   xmppAnonymousDomain: 'anon.example.com',
 


### PR DESCRIPTION
See issue #58 https://github.com/buddycloud/buddycloud-http-api/issues/58
