### PR TITLE
If no media server defined, don't fill logs with errors and 503 to end user

### DIFF
--- a/src/media.js
+++ b/src/media.js
@@ -60,6 +60,7 @@ function generateTransactionId() {
 }
 
 function getMediaUrl(req, transactionId) {
+  if (!req.mediaRoot) return;
   var mediaUrl = url.parse(req.mediaRoot);
   ensureTrailingSlash(mediaUrl);
   mediaUrl.pathname += req.params.channel;
@@ -89,6 +90,7 @@ function base64url(buf) {
 }
 
 function forwardRequest(req, res, mediaUrl) {
+  if (!mediaUrl) return res.send(503);
   mediaUrl = url.parse(mediaUrl);
   req.headers['host'] = mediaUrl.host;
 

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -193,7 +193,7 @@ exports.mediaServerDiscoverer = function(req, res, next) {
   dns.discoverAPI(req, function(mediaRoot) {
     if (mediaRoot) {
       req.mediaRoot = mediaRoot;
-    } else {
+    } else if (config.homeMediaRoot) {
       req.mediaRoot = config.homeMediaRoot;
     }
     next();

--- a/src/util/dns.js
+++ b/src/util/dns.js
@@ -68,6 +68,7 @@ exports.discoverAPI = function(req, callback) {
   var remoteDomain = channel.split('@')[1];
   
   if (remoteDomain == config.xmppDomain) {
+    if (!config.homeMediaRoot) return callback();
     mediaRoot = config.homeMediaRoot;
     localMediaAddress = mediaRoot.split('://')[1];
     localMediaAddressSplit = localMediaAddress.split(':');


### PR DESCRIPTION
This fixes #84, and improves the situation in #81

When making requests to media server (and none is defined) a 503 response is returned.
