### PR TITLE
Fixes affiliation changes

### DIFF
--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -40,6 +40,7 @@ exports.setup = function(app) {
           session.provider,
           getNodeSubscriptions);
   app.post('/:channel/subscribers/:node',
+          api.bodyReader,
           session.provider,
           changeNodeSubscriptions);
 };
@@ -177,13 +178,6 @@ function requestNodeAffiliations(req, res, channel, node, callback) {
 
 //// POST /<channel>/subscribers/<node> //////////////////////////////////////////////////////////
 
-function isValidAffiliation(affiliation){
-  return (
-    affiliation == "member" || affiliation == "publisher" ||
-    affiliation == "moderator" || affiliation == "outcast"
-  )
-}
-
 function changeNodeSubscriptions(req, res) {
   if (!req.user) {
     api.sendUnauthorized(res);
@@ -197,32 +191,17 @@ function changeNodeSubscriptions(req, res) {
   var newSubscribedAffiliations = [];
 
   try {
-
-    for ( var key in req.body ){
-
-      var jid = key;
-      var affiliation = body[key];
-
-      if ( !isValidAffiliation(affiliation) ){
-        continue;
-      }
-
-      //TODO
-      //Also filter out from newSubscribedAffiliations those channel jids which aren't actually subscribed to this node.
-      //Probably by performing a getNodeSubscriptions and comparing the results with the new affiliation information given by the user
-
-      newSubscribedAffiliations.push({
-        'jid' : jid,
-        'affiliation' : affiliation
-      });
-    }
-
+    var newAffiliations = JSON.parse(req.body);
+    // TODO Filter out from newAffiliations those channel jids which aren't actually subscribed to this node.
+    // Probably by performing a getNodeSubscriptions and comparing the results with the new affiliation information given by the user
   } catch (e) {
     res.send(400);
   }
 
-  api.sendQuery(req, res, pubsub.changeNodeAffiliationsIq(nodeId, newSubscribedAffiliations), function(){
-    res.send(200);
-  });
+  api.sendQuery(req, res, 
+    pubsub.changeNodeAffiliationsIq(nodeId, newAffiliations), 
+    function() {
+      res.send(200);
+    });
 
 }

--- a/src/util/pubsub.js
+++ b/src/util/pubsub.js
@@ -137,14 +137,13 @@ exports.nodeAffiliationsIq = function(nodeId, item) {
  * The <subscribedJIDAndAffiliation> parameter must be an array of entries in the format:
  * {'jid' : 'jid_val', 'affiliation' : 'affiliation_type'}
  */
-exports.changeNodeAffiliationsIq = function(nodeId, subscribedJIDAndAffiliation) {
+exports.changeNodeAffiliationsIq = function(nodeId, newAffiliations) {
   var iqBody = iq({type : 'set'}, exports.ownerNS).
 	  c('affiliations', {node: nodeId});
-
-  for ( var i=0; i<subscribedJIDAndAffiliation.length; i++ ){
-    iqBody.c('affiliation', subscribedJIDAndAffiliation[i]);
+  for (var jid in newAffiliations) {
+    var affiliation = newAffiliations[jid];
+    iqBody.c('affiliation', {jid: jid, affiliation: affiliation});
   }
-
   return iqBody.root();
 };
 


### PR DESCRIPTION
Current code does not parse the HTTP body. It also verifies for correct affiliations names, which, IMO, should be a job for the channel server. I also did a few minor changes to make the code cleaner.
