### PR TITLE
Fix nodejs 0.8 building in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
   # https://github.com/travis-ci/travis-cookbooks/issues/155
   - sudo rm -rf /dev/shm
   - sudo ln -s /run/shm /dev/shm
-before_script:
   - npm install -g grunt-cli
 language: node_js
 node_js:


### PR DESCRIPTION
Due to older version of npm and the '^' in version numbers.
