### PR TITLE
Avoid XMPP reconnection

### DIFF
--- a/src/util/session.js
+++ b/src/util/session.js
@@ -183,8 +183,7 @@ function xmppConnectionOptions(req) {
     return {
       jid: '@' + domain,
       host: host,
-      port: port,
-      reconnect: false,
+      port: port
       //preferredSaslMechanism: 'ANONYMOUS'
     };
   }


### PR DESCRIPTION
When the XMPP server goes down, pending and new requests hangs waiting for reconnection. This makes the API unresponsive until the reconnection strategy kicks in. This change deactivates the `reconnect` flag and makes the server return 503 for any request during the offiline state.
